### PR TITLE
Substituted lscpu with /proc/cpuinfo

### DIFF
--- a/minikube_demo_setup.sh
+++ b/minikube_demo_setup.sh
@@ -61,7 +61,8 @@ function print_min_resources() {
 
 # Checks if the system which tries to run autotune is having minimum resources required
 function sys_cpu_mem_check() {
-	SYS_CPU=$(lscpu -p | grep -v '^#' | wc -l)
+	cpuinfo=/proc/cpuinfo
+	SYS_CPU=$(awk '/^cpu cores/' <"$cpuinfo" )
 	SYS_MEM=$(grep MemTotal /proc/meminfo | awk '{printf ("%.0f\n", $2/(1024))}')
 
 	if [ "${SYS_CPU}" -lt "${MIN_CPU}" ]; then

--- a/minikube_demo_setup.sh
+++ b/minikube_demo_setup.sh
@@ -61,10 +61,7 @@ function print_min_resources() {
 
 # Checks if the system which tries to run autotune is having minimum resources required
 function sys_cpu_mem_check() {
-	cpuinfo=/proc/cpuinfo
-	core=$(awk '/^cpu cores/{print $4; exit}' <"$cpuinfo" )
-	siblings=$(awk '/^siblings/{print $3; exit}' <"$cpuinfo")
-	SYS_CPU=$((core * siblings))
+	SYS_CPU=$(cat /proc/cpuinfo | grep "^processor" | wc -l)
 	SYS_MEM=$(grep MemTotal /proc/meminfo | awk '{printf ("%.0f\n", $2/(1024))}')
 
 	if [ "${SYS_CPU}" -lt "${MIN_CPU}" ]; then

--- a/minikube_demo_setup.sh
+++ b/minikube_demo_setup.sh
@@ -62,7 +62,9 @@ function print_min_resources() {
 # Checks if the system which tries to run autotune is having minimum resources required
 function sys_cpu_mem_check() {
 	cpuinfo=/proc/cpuinfo
-	SYS_CPU=$(awk '/^cpu cores/' <"$cpuinfo" )
+	core=$(awk '/^cpu cores/{print $4; exit}' <"$cpuinfo" )
+	siblings=$(awk '/^siblings/{print $3; exit}' <"$cpuinfo")
+	SYS_CPU=$((core * siblings))
 	SYS_MEM=$(grep MemTotal /proc/meminfo | awk '{printf ("%.0f\n", $2/(1024))}')
 
 	if [ "${SYS_CPU}" -lt "${MIN_CPU}" ]; then


### PR DESCRIPTION
The change has been made as the lscpu did not work on some of the machines, and /proc/cpuinfo is globally accepted in all the machines.
Signed-off-by: Aditya Deshmukh adityadeshplayer@gmail.com